### PR TITLE
feat: select ignoreValues option

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -45,17 +45,30 @@ const isAdult = await confirm('Are you over 18 ?', { initial: true })
 
 ## API
 
-### `prompt(message: string): Promise<string>`
+### `prompt()`
+
+```ts
+prompt(message: string): Promise<string>
+```
 
 Simple prompt, similar to `rl.question()` with an improved UI.
 
-### `select(message: string, options: { choices: (Choice | string)[], maxVisible?: number }): Promise<string>`
+### `select()`
+
+```ts
+select(message: string, options: { choices: (Choice | string)[], maxVisible?: number, ignoreValues?: (string | number | boolean)[] }): Promise<string>
+```
 
 Scrollable select depending `maxVisible` (default `8`).
+Use `ignoreValues` to skip result render & clear lines after a selected one.
 
-### `confirm(message: string, options?: { initial: boolean }): Promise<string>`
+### `confirm()`
 
-Boolean prompt.
+```ts
+confirm(message: string, options?: { initial: boolean }): Promise<string>
+```
+
+Boolean prompt, return `options.initial` if user input is different from "y"/"yes"/"n"/"no", (default `false`).
 
 ## Interfaces
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,5 +4,5 @@ export interface Choice {
   description?: string,
 }
 export function prompt(message: string): Promise<string>;
-export function select(message: string, options: { choices: (Choice | string)[], maxVisble?: number }): Promise<string>;
+export function select(message: string, options: { choices: (Choice | string)[], maxVisble?: number, ignoreValues: (string | number | boolean)[] }): Promise<string>;
 export function confirm(message: string, options?: { initial: boolean }): Promise<string>;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "type": "module",
   "devDependencies": {
     "snazzy": "^9.0.0",
-    "standard": "^17.0.0"
+    "standard": "^17.0.0",
+    "strip-ansi": "^7.0.1"
   },
   "dependencies": {
     "ansi-styles": "^6.2.1"

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -1,7 +1,10 @@
 import { select } from '../index.js'
 
+import stripAnsi from 'strip-ansi'
+
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
+import { EOL } from 'node:os'
 
 describe('select', () => {
   it('message should be required', async () => {
@@ -44,5 +47,204 @@ describe('select', () => {
         message: 'Missing value for choice {"label":"foo","description":"bar"}'
       }
     )
+  })
+
+  it('When press <return>, it should select the first choice.', async () => {
+    const logs = []
+    const mockStdout = {
+      write: (msg) => {
+        const noAnsiMsg = stripAnsi(msg)
+        if (noAnsiMsg) {
+          logs.push(noAnsiMsg)
+        }
+      },
+      moveCursor: () => {},
+      clearScreenDown: () => {},
+      clearLine: () => {}
+    }
+    const mockStdin = {
+      on: (event, cb) => cb(null, { name: 'return' }),
+      off: () => {}
+    }
+
+    await select('foo', { choices: ['choice1', 'choice2'], stdout: mockStdout, stdin: mockStdin })
+
+    assert.deepEqual(logs, [`? foo${EOL}`, ` › choice1${EOL}`, `   choice2${EOL}`, `✔ foo › choice1${EOL}`])
+  })
+
+  it('When press <down> then <return>, it should select the second choice.', async () => {
+    const logs = []
+    const mockInputs = [
+      { name: 'down' },
+      { name: 'return' }
+    ]
+    const mockStdout = {
+      write: (msg) => {
+        const noAnsiMsg = stripAnsi(msg)
+        if (noAnsiMsg) {
+          logs.push(noAnsiMsg)
+        }
+      },
+      moveCursor: () => {},
+      clearScreenDown: () => {},
+      clearLine: () => {}
+    }
+    const mockStdin = {
+      on: (event, cb) => {
+        cb(null, mockInputs.shift())
+        cb(null, mockInputs.shift())
+      },
+      off: () => {}
+    }
+
+    const value = await select('foo', { choices: ['choice1', 'choice2'], stdout: mockStdout, stdin: mockStdin })
+
+    assert.deepEqual(logs, [
+      `? foo${EOL}`,
+      ` › choice1${EOL}`,
+      `   choice2${EOL}`,
+      `   choice1${EOL}`,
+      ` › choice2${EOL}`,
+      `✔ foo › choice2${EOL}`
+    ])
+    assert.deepEqual(value, 'choice2')
+  })
+
+  it('It should work with choice objects.', async () => {
+    const logs = []
+    const mockStdout = {
+      write: (msg) => {
+        const noAnsiMsg = stripAnsi(msg)
+        if (noAnsiMsg) {
+          logs.push(noAnsiMsg)
+        }
+      },
+      moveCursor: () => {},
+      clearScreenDown: () => {},
+      clearLine: () => {}
+    }
+    const mockStdin = {
+      on: (event, cb) => cb(null, { name: 'return' }),
+      off: () => {}
+    }
+
+    await select('foo', {
+      choices: [
+        { value: 'choice1', label: 'choice1' },
+        { value: 'choice2', label: 'choice2' }
+      ],
+      stdout: mockStdout,
+      stdin: mockStdin
+    })
+
+    assert.deepEqual(logs, [`? foo${EOL}`, ` › choice1${EOL}`, `   choice2${EOL}`, `✔ foo › choice1${EOL}`])
+  })
+
+  it('When the first item is selected and the up arrow is pressed, the last item should be selected.', async () => {
+    const logs = []
+    const mockInputs = [
+      { name: 'down' },
+      { name: 'return' }
+    ]
+    const mockStdout = {
+      write: (msg) => {
+        const noAnsiMsg = stripAnsi(msg)
+        if (noAnsiMsg) {
+          logs.push(noAnsiMsg)
+        }
+      },
+      moveCursor: () => {},
+      clearScreenDown: () => {},
+      clearLine: () => {}
+    }
+    const mockStdin = {
+      on: (event, cb) => {
+        cb(null, mockInputs.shift())
+        cb(null, mockInputs.shift())
+      },
+      off: () => {}
+    }
+
+    const value = await select('foo', { choices: ['choice1', 'choice2'], stdout: mockStdout, stdin: mockStdin })
+
+    assert.deepEqual(logs, [
+      `? foo${EOL}`,
+      ` › choice1${EOL}`,
+      `   choice2${EOL}`,
+      `   choice1${EOL}`,
+      ` › choice2${EOL}`,
+      `✔ foo › choice2${EOL}`
+    ])
+    assert.deepEqual(value, 'choice2')
+  })
+
+  it('When the last item is selected and the down arrow is pressed, the first item should be selected.', async () => {
+    const logs = []
+    const mockInputs = [
+      { name: 'down' },
+      { name: 'down' },
+      { name: 'return' }
+    ]
+    const mockStdout = {
+      write: (msg) => {
+        const noAnsiMsg = stripAnsi(msg)
+        if (noAnsiMsg) {
+          logs.push(noAnsiMsg)
+        }
+      },
+      moveCursor: () => {},
+      clearScreenDown: () => {},
+      clearLine: () => {}
+    }
+    const mockStdin = {
+      on: (event, cb) => {
+        cb(null, mockInputs.shift())
+        cb(null, mockInputs.shift())
+        cb(null, mockInputs.shift())
+      },
+      off: () => {}
+    }
+
+    const value = await select('foo', { choices: ['choice1', 'choice2'], stdout: mockStdout, stdin: mockStdin })
+
+    assert.deepEqual(logs, [
+      `? foo${EOL}`,
+      ` › choice1${EOL}`,
+      `   choice2${EOL}`,
+      `   choice1${EOL}`,
+      ` › choice2${EOL}`,
+      ` › choice1${EOL}`,
+      `   choice2${EOL}`,
+      `✔ foo › choice1${EOL}`
+    ])
+    assert.deepEqual(value, 'choice1')
+  })
+
+  it('should ignore choice2', async () => {
+    const logs = []
+    const mockStdout = {
+      write: (msg) => {
+        const noAnsiMsg = stripAnsi(msg)
+        if (noAnsiMsg) {
+          logs.push(noAnsiMsg)
+        }
+      },
+      moveCursor: () => {},
+      clearScreenDown: () => {},
+      clearLine: () => {}
+    }
+    const mockStdin = {
+      on: (event, cb) => cb(null, { name: 'return' }),
+      off: () => {}
+    }
+
+    await select('foo', { choices: ['choice1', 'choice2'], ignoreValues: ['choice1'], stdout: mockStdout, stdin: mockStdin })
+
+    assert.deepEqual(logs, [
+      `? foo${EOL}`,
+      ` › choice1${EOL}`,
+      `   choice2${EOL}`
+      // '✔ foo › choice1']
+    ])
   })
 })

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -220,7 +220,7 @@ describe('select', () => {
     assert.deepEqual(value, 'choice1')
   })
 
-  it('should ignore choice2', async () => {
+  it('should ignore choice1', async () => {
     const logs = []
     const mockStdout = {
       write: (msg) => {


### PR DESCRIPTION
`ignoreValues` allow to skip result rendering and clear prompt

* Fixed `prompt` ui to be consistency
* `select` re-render now clear the whole lines
* Added compatibility for Node.js < v17