### PR TITLE
feat(prompt): add validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,24 @@ console.log(name, runner, isCLI)
 ### `prompt()`
 
 ```ts
-prompt(message: string): Promise<string>
+prompt(message: string, options?: PromptOptions): Promise<string>
 ```
 
 Simple prompt, similar to `rl.question()` with an improved UI.
+Use `options.validators` to handle user input.
+
+**Example**
+
+```js
+const packageName = await prompt('Package name', {
+  validators: [
+    {
+      validate: (value) => !existsSync(join(process.cwd(), value)),
+      error: (value) => `Folder ${value} already exists`
+    }
+  ]
+})
+```
 
 ### `select()`
 
@@ -67,6 +81,14 @@ Boolean prompt, return `options.initial` if user input is different from "y"/"ye
 
 ## Interfaces
 
+```ts
+export interface PromptOptions {
+  validators?: {
+    validate: (input: string) => boolean;
+    error: (input: string) => string;
+  }[];
+}
+```
 ```ts
 export interface Choice {
   value: any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,10 @@
+export interface PromptOptions {
+  validators?: {
+    validate: (input: string) => boolean;
+    error: (input: string) => string;
+  }[];
+}
+
 export interface Choice {
   value: any;
   label: string;
@@ -14,6 +21,6 @@ export interface ConfirmOptions {
   initial?: boolean;
 }
 
-export function prompt(message: string): Promise<string>;
+export function prompt(message: string, options?: PromptOptions): Promise<string>;
 export function select(message: string, options: SelectOptions): Promise<string>;
 export function confirm(message: string, options?: ConfirmOptions): Promise<string>;

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ import { ConfirmPrompt } from "./src/confirm-prompt.js";
 import { SelectPrompt } from "./src/select-prompt.js";
 import { TextPrompt } from "./src/text-prompt.js";
 
-export async function prompt(message) {
-  const textPrompt = new TextPrompt(message);
+export async function prompt(message, options = {}) {
+  const textPrompt = new TextPrompt(message, options);
 
   return textPrompt.question();
 }

--- a/package.json
+++ b/package.json
@@ -26,12 +26,11 @@
     "@nodesecure/eslint-config": "^1.7.0",
     "c8": "^7.13.0",
     "eslint": "^8.38.0",
-    "esmock": "^2.1.0",
-    "snazzy": "^9.0.0",
-    "strip-ansi": "^7.0.1"
+    "esmock": "^2.1.0"
   },
   "dependencies": {
-    "ansi-styles": "^6.2.1"
+    "ansi-styles": "^6.2.1",
+    "strip-ansi": "^7.0.1"
   },
   "engines": {
     "node": ">=14"

--- a/src/confirm-prompt.js
+++ b/src/confirm-prompt.js
@@ -8,14 +8,15 @@ import ansi from "ansi-styles";
 import { AbstractPrompt } from "./abstract-prompt.js";
 import { SYMBOLS } from "./constants.js";
 
-const kDefaultConfirmOptions = { initial: false };
-
 export class ConfirmPrompt extends AbstractPrompt {
-  // eslint-disable-next-line max-params
-  constructor(message, options = {}, stdin = process.stdin, stdout = process.stdout) {
+  constructor(message, options = {}) {
+    const {
+      stdin = process.stdin,
+      stdout = process.stdout,
+      initial = false
+    } = options;
     super(message, stdin, stdout);
 
-    const { initial } = { ...kDefaultConfirmOptions, ...options };
     const Yes = `${ansi.bold.open}Yes${ansi.bold.close}`;
     const No = `${ansi.bold.open}No${ansi.bold.close}`;
     const tip = initial ? `${Yes}/no` : `yes/${No}`;
@@ -25,15 +26,22 @@ export class ConfirmPrompt extends AbstractPrompt {
 
   #question() {
     return new Promise((resolve) => {
-      const label = `${ansi.bold.open}${SYMBOLS.QuestionMark} ${this.message}${ansi.bold.close}`;
-      const question = `${label} ${ansi.grey.open}(${this.initial ? "Yes/no" : "yes/No"})${ansi.grey.close} `;
-      this.rl.question(question,
+      const questionQuery = this.#getQuestionQuery();
+
+      this.rl.question(questionQuery,
         (answer) => {
-          this.history.push(question + answer);
+          this.history.push(questionQuery + answer);
+
           resolve(answer);
         }
       );
     });
+  }
+
+  #getQuestionQuery() {
+    const query = `${ansi.bold.open}${SYMBOLS.QuestionMark} ${this.message}${ansi.bold.close}`;
+
+    return `${query} ${ansi.grey.open}(${this.initial ? "Yes/no" : "yes/No"})${ansi.grey.close} `;
   }
 
   #onQuestionAnswer() {

--- a/src/select-prompt.js
+++ b/src/select-prompt.js
@@ -11,8 +11,17 @@ import { SYMBOLS } from "./constants.js";
 export class SelectPrompt extends AbstractPrompt {
   activeIndex = 0;
 
-  // eslint-disable-next-line max-params
-  constructor(message, options, stdin = process.stdin, stdout = process.stdout) {
+  get choices() {
+    return this.options.choices;
+  }
+
+  constructor(message, options) {
+    const {
+      stdin = process.stdin,
+      stdout = process.stdout,
+      choices
+    } = options ?? {};
+
     super(message, stdin, stdout);
 
     if (!options) {
@@ -21,14 +30,12 @@ export class SelectPrompt extends AbstractPrompt {
     }
 
     this.options = options;
-    const { choices } = options;
 
     if (!choices?.length) {
       this.destroy();
       throw new TypeError("Missing required param: choices");
     }
 
-    this.choices = choices;
     this.longestChoice = Math.max(...choices.map((choice) => {
       if (typeof choice === "string") {
         return choice.length;
@@ -47,64 +54,92 @@ export class SelectPrompt extends AbstractPrompt {
     }));
   }
 
-  async select() {
-    this.write(SYMBOLS.HideCursor);
-    this.write(`${ansi.bold.open}${SYMBOLS.QuestionMark} ${this.message}${ansi.bold.close}${EOL}`);
+  #getFormattedChoice(choiceIndex) {
+    const choice = this.choices[choiceIndex];
 
-    let lastRender = null;
-    const render = (initialRender = false, { reset } = {}) => {
-      function getVisibleChoices(currentIndex, total, maxVisible) {
-        let startIndex = Math.min(total - maxVisible, currentIndex - Math.floor(maxVisible / 2));
-        if (startIndex < 0) {
-          startIndex = 0;
-        }
+    if (typeof choice === "string") {
+      return { value: choice, label: choice };
+    }
 
-        const endIndex = Math.min(startIndex + maxVisible, total);
+    return choice;
+  }
 
-        return { startIndex, endIndex };
+  #getVisibleChoices() {
+    const maxVisible = this.options.maxVisible || 8;
+    let startIndex = Math.min(this.choices.length - maxVisible, this.activeIndex - Math.floor(maxVisible / 2));
+    if (startIndex < 0) {
+      startIndex = 0;
+    }
+
+    const endIndex = Math.min(startIndex + maxVisible, this.choices.length);
+
+    return { startIndex, endIndex };
+  }
+
+  #showChoices() {
+    const { startIndex, endIndex } = this.#getVisibleChoices();
+    this.lastRender = { startIndex, endIndex };
+
+    for (let choiceIndex = startIndex; choiceIndex < endIndex; choiceIndex++) {
+      const choice = this.#getFormattedChoice(choiceIndex);
+      const showPreviousChoicesArrow = startIndex > 0 && choiceIndex === startIndex;
+      const showNextChoicesArrow = endIndex < this.choices.length && choiceIndex === endIndex - 1;
+
+      let prefixArrow = " ";
+      if (showPreviousChoicesArrow) {
+        prefixArrow = SYMBOLS.Previous;
+      }
+      else if (showNextChoicesArrow) {
+        prefixArrow = SYMBOLS.Next;
       }
 
-      const { startIndex, endIndex } = getVisibleChoices(this.activeIndex, this.choices.length, this.options.maxVisible || 8);
+      const prefix = `${prefixArrow}${choiceIndex === this.activeIndex ? `${SYMBOLS.Active} ` : `${SYMBOLS.Inactive}  `}`;
+      const formattedLabel = choice.label.padEnd(
+        this.longestChoice < 10 ? this.longestChoice : 0
+      );
+      const formattedDescription = choice.description ? ` - ${choice.description}` : "";
+      const str = `${prefix}${formattedLabel}${formattedDescription}${ansi.reset.open}${EOL}`;
+
+      this.write(str);
+    }
+  }
+
+  #showAnsweredQuestion(choice) {
+    const prefix = `${ansi.bold.open}${SYMBOLS.Tick} ${this.message} ${SYMBOLS.Pointer}`;
+    const formattedChoice = `${ansi.yellow.open}${choice.label ?? choice}${ansi.reset.open}`;
+
+    this.write(`${prefix} ${formattedChoice}${EOL}`);
+  }
+
+  async select() {
+    this.write(SYMBOLS.HideCursor);
+    this.#showQuestion();
+
+    const render = (options = {}) => {
+      const {
+        initialRender = false,
+        clearRender = false
+      } = options;
 
       if (!initialRender) {
-        let linesToClear = lastRender.endIndex - lastRender.startIndex;
+        let linesToClear = this.lastRender.endIndex - this.lastRender.startIndex;
         while (linesToClear > 0) {
           this.clearLastLine();
           linesToClear--;
         }
       }
 
-      if (reset) {
+      if (clearRender) {
         this.stdout.moveCursor(0, -2);
         this.stdout.clearScreenDown();
 
         return;
       }
 
-      lastRender = { startIndex, endIndex };
-
-      for (let i = startIndex; i < endIndex; i++) {
-        const choice = typeof this.choices[i] === "string" ? { value: this.choices[i], label: this.choices[i] } : this.choices[i];
-        const showPreviousChoicesArrow = startIndex > 0 && i === startIndex;
-        const showNextChoicesArrow = endIndex < this.choices.length && i === endIndex - 1;
-        let prefixArrow = " ";
-        if (showPreviousChoicesArrow) {
-          prefixArrow = SYMBOLS.Previous;
-        }
-        else if (showNextChoicesArrow) {
-          prefixArrow = SYMBOLS.Next;
-        }
-        const prefix = `${prefixArrow}${i === this.activeIndex ? `${SYMBOLS.Active} ` : `${SYMBOLS.Inactive}  `}`;
-        const str = `${prefix}${choice.label.padEnd(
-          this.longestChoice < 10 ? this.longestChoice : 0
-        )}${choice.description ? ` - ${choice.description}` : ""}${ansi.reset.open}${EOL}`;
-        if (!reset) {
-          this.write(str);
-        }
-      }
+      this.#showChoices();
     };
 
-    render(true);
+    render({ initialRender: true });
 
     return new Promise((resolve) => {
       const onKeypress = (value, key) => {
@@ -119,23 +154,27 @@ export class SelectPrompt extends AbstractPrompt {
         else if (key.name === "return") {
           this.stdin.off("keypress", onKeypress);
 
-          render(false, { reset: true });
+          render({ clearRender: true });
+
           const currentChoice = this.choices[this.activeIndex];
           const value = currentChoice.value ?? currentChoice;
 
           if (!this.options.ignoreValues?.includes(value)) {
-            const prefix = `${ansi.bold.open}${SYMBOLS.Tick} ${this.message} ${SYMBOLS.Pointer}`;
-            const choice = `${ansi.yellow.open}${currentChoice.label ?? currentChoice}${ansi.reset.open}`;
-            this.write(`${prefix} ${choice}${EOL}`);
+            this.#showAnsweredQuestion(currentChoice);
           }
 
           this.write(SYMBOLS.ShowCursor);
           this.destroy();
+
           resolve(value);
         }
       };
 
       this.stdin.on("keypress", onKeypress);
     });
+  }
+
+  #showQuestion() {
+    this.write(`${ansi.bold.open}${SYMBOLS.QuestionMark} ${this.message}${ansi.bold.close}${EOL}`);
   }
 }

--- a/src/select-prompt.js
+++ b/src/select-prompt.js
@@ -48,8 +48,8 @@ export class SelectPrompt extends AbstractPrompt {
   }
 
   async select() {
-    this.stdout.write(SYMBOLS.HideCursor);
-    this.stdout.write(`${ansi.bold.open}${SYMBOLS.QuestionMark} ${this.message}${ansi.bold.close}${EOL}`);
+    this.write(SYMBOLS.HideCursor);
+    this.write(`${ansi.bold.open}${SYMBOLS.QuestionMark} ${this.message}${ansi.bold.close}${EOL}`);
 
     let lastRender = null;
     const render = (initialRender = false, { reset } = {}) => {
@@ -67,14 +67,16 @@ export class SelectPrompt extends AbstractPrompt {
       const { startIndex, endIndex } = getVisibleChoices(this.activeIndex, this.choices.length, this.options.maxVisible || 8);
 
       if (!initialRender) {
-        const linesToClear = lastRender.endIndex - lastRender.startIndex;
-        this.stdout.moveCursor(0, -linesToClear);
-        this.stdout.clearScreenDown();
+        let linesToClear = lastRender.endIndex - lastRender.startIndex;
+        while (linesToClear > 0) {
+          this.clearLastLine();
+          linesToClear--;
+        }
       }
 
       if (reset) {
-        this.clearLastLine(this.stdout);
-        this.clearLastLine(this.stdout);
+        this.stdout.moveCursor(0, -2);
+        this.stdout.clearScreenDown();
 
         return;
       }
@@ -96,7 +98,9 @@ export class SelectPrompt extends AbstractPrompt {
         const str = `${prefix}${choice.label.padEnd(
           this.longestChoice < 10 ? this.longestChoice : 0
         )}${choice.description ? ` - ${choice.description}` : ""}${ansi.reset.open}${EOL}`;
-        this.stdout.write(str);
+        if (!reset) {
+          this.write(str);
+        }
       }
     };
 
@@ -118,13 +122,14 @@ export class SelectPrompt extends AbstractPrompt {
           render(false, { reset: true });
           const currentChoice = this.choices[this.activeIndex];
           const value = currentChoice.value ?? currentChoice;
+
           if (!this.options.ignoreValues?.includes(value)) {
             const prefix = `${ansi.bold.open}${SYMBOLS.Tick} ${this.message} ${SYMBOLS.Pointer}`;
             const choice = `${ansi.yellow.open}${currentChoice.label ?? currentChoice}${ansi.reset.open}`;
-            this.stdout.write(`${prefix} ${choice}${EOL}`);
+            this.write(`${prefix} ${choice}${EOL}`);
           }
 
-          this.stdout.write(SYMBOLS.ShowCursor);
+          this.write(SYMBOLS.ShowCursor);
           this.destroy();
           resolve(value);
         }

--- a/src/text-prompt.js
+++ b/src/text-prompt.js
@@ -3,41 +3,64 @@ import { EOL } from "node:os";
 
 // Import Third-party Dependencies
 import ansi from "ansi-styles";
+import stripAnsi from "strip-ansi";
 
 // Import Internal Dependencies
 import { AbstractPrompt } from "./abstract-prompt.js";
 import { SYMBOLS } from "./constants.js";
 
 export class TextPrompt extends AbstractPrompt {
-  #question;
+  #validators;
 
-  constructor(message, stdin = process.stdin, stdout = process.stdout) {
+  constructor(message, options = {}) {
+    const { stdin = process.stdin, stdout = process.stdout, validators = [] } = options;
     super(message, stdin, stdout);
 
-    this.#question = new Promise((resolve) => {
-      this.rl.question(`${ansi.bold.open}${SYMBOLS.QuestionMark} ${message}${ansi.bold.close} `, (answer) => {
+    this.#validators = validators;
+    this.questionPrefix = `${ansi.bold.open}${SYMBOLS.QuestionMark} `;
+    this.questionSuffix = `${ansi.bold.close} `;
+    this.questionSuffixError = "";
+  }
+
+  #question() {
+    return new Promise((resolve) => {
+      const question = `${this.questionPrefix}${this.message}${this.questionSuffix}${this.questionSuffixError}`;
+      this.rl.question(question, (answer) => {
+        this.history.push(question + answer);
         resolve(answer);
       });
     });
   }
 
-  #onQuestionAnswer() {
+  async #onQuestionAnswer() {
     this.clearLastLine();
+
+    for (const validator of this.#validators) {
+      if (!validator.validate(this.answer)) {
+        this.questionSuffixError = `${ansi.red.open}[${validator.error(this.answer)}]${ansi.red.close}${ansi.bold.close} `;
+        this.answer = this.#question();
+
+        return;
+      }
+    }
+
     const prefix = `${ansi.bold.open}${this.answer ? SYMBOLS.Tick : SYMBOLS.Cross}`;
     const suffix = `${ansi.yellow.close}${ansi.bold.close}${EOL}`;
-    this.stdout.write(`${prefix} ${this.message} ${SYMBOLS.Pointer} ${ansi.yellow.open}${this.answer ?? ""}${suffix}`);
+    this.write(`${prefix} ${this.message} ${SYMBOLS.Pointer} ${ansi.yellow.open}${this.answer ?? ""}${suffix}`);
   }
 
   async question() {
-    try {
-      this.answer = await this.#question;
+    this.answer = await this.#question();
 
-      this.#onQuestionAnswer();
+    await this.#onQuestionAnswer();
 
-      return this.answer;
+    while (this.answer?.constructor.name === "Promise") {
+      this.answer = await this.answer;
+      await this.#onQuestionAnswer();
     }
-    finally {
-      this.destroy();
-    }
+
+    this.destroy();
+
+    return this.answer;
   }
 }

--- a/test/confirm-prompt.test.js
+++ b/test/confirm-prompt.test.js
@@ -18,7 +18,7 @@ describe("ConfirmPrompt", () => {
 
     assert.deepEqual(input, false);
     assert.deepEqual(logs, [
-      "? Foo  (yes/No)",
+      "? Foo (yes/No)",
       "✖ Foo"
     ]);
   });
@@ -30,7 +30,7 @@ describe("ConfirmPrompt", () => {
 
     assert.deepEqual(input, true);
     assert.deepEqual(logs, [
-      "? Foo  (yes/No)",
+      "? Foo (yes/No)",
       "✔ Foo"
     ]);
   });
@@ -42,7 +42,7 @@ describe("ConfirmPrompt", () => {
 
     assert.deepEqual(input, true);
     assert.deepEqual(logs, [
-      "? Foo  (yes/No)",
+      "? Foo (yes/No)",
       "✔ Foo"
     ]);
   });
@@ -54,7 +54,7 @@ describe("ConfirmPrompt", () => {
 
     assert.deepEqual(input, false);
     assert.deepEqual(logs, [
-      "? Foo  (yes/No)",
+      "? Foo (yes/No)",
       "✖ Foo"
     ]);
   });
@@ -66,7 +66,7 @@ describe("ConfirmPrompt", () => {
 
     assert.deepEqual(input, false);
     assert.deepEqual(logs, [
-      "? Foo  (yes/No)",
+      "? Foo (yes/No)",
       "✖ Foo"
     ]);
   });
@@ -78,7 +78,7 @@ describe("ConfirmPrompt", () => {
 
     assert.deepEqual(input, true);
     assert.deepEqual(logs, [
-      "? Foo  (yes/No)",
+      "? Foo (yes/No)",
       "✔ Foo"
     ]);
   });
@@ -90,7 +90,7 @@ describe("ConfirmPrompt", () => {
 
     assert.deepEqual(input, true);
     assert.deepEqual(logs, [
-      "? Foo  (Yes/no)",
+      "? Foo (Yes/no)",
       "✔ Foo"
     ]);
   });

--- a/test/helpers/testing-prompt.js
+++ b/test/helpers/testing-prompt.js
@@ -6,13 +6,16 @@ import esmock from "esmock";
 import { mockProcess } from "./mock-process.js";
 
 export class TestingPrompt {
-  static async TextPrompt(message, input, onStdoutWriteCallback) {
+  // eslint-disable-next-line max-params
+  static async TextPrompt(message, input, onStdoutWriteCallback, validators) {
+    const inputs = Array.isArray(input) ? input : [input];
+
     const { TextPrompt } = await esmock("../../src/text-prompt", { }, {
       readline: {
         createInterface: () => {
           return {
             question: (query, onInput) => {
-              onInput(input);
+              onInput(inputs.shift());
               onStdoutWriteCallback(stripAnsi(query).trim());
             },
             close: () => true
@@ -22,7 +25,7 @@ export class TestingPrompt {
     });
     const { stdin, stdout } = mockProcess([], (data) => onStdoutWriteCallback(data));
 
-    return new TextPrompt(message, stdin, stdout);
+    return new TextPrompt(message, { stdin, stdout, validators });
   }
 
   // eslint-disable-next-line max-params

--- a/test/helpers/testing-prompt.js
+++ b/test/helpers/testing-prompt.js
@@ -41,7 +41,7 @@ export class TestingPrompt {
     });
     const { stdin, stdout } = mockProcess(input, (data) => onStdoutWriteCallback(data));
 
-    return new SelectPrompt(message, options, stdin, stdout);
+    return new SelectPrompt(message, { ...options, stdin, stdout });
   }
 
   // eslint-disable-next-line max-params
@@ -62,6 +62,6 @@ export class TestingPrompt {
     const { stdin, stdout } = mockProcess(input, (data) => onStdoutWriteCallback(data));
     const options = typeof initial === "boolean" ? { initial } : {};
 
-    return new ConfirmPrompt(message, options, stdin, stdout);
+    return new ConfirmPrompt(message, { ...options, stdin, stdout });
   }
 }

--- a/test/text-prompt.test.js
+++ b/test/text-prompt.test.js
@@ -32,4 +32,25 @@ describe("TextPrompt", () => {
       "✖ What's your name? › "
     ]);
   });
+
+  it("validator should not pass", async() => {
+    const logs = [];
+    const textPrompt = await TestingPrompt.TextPrompt(
+      "What's your name?",
+      ["test1", "test10", "test2"],
+      (log) => logs.push(log),
+      [{
+        validate: (input) => !input.startsWith("test1"),
+        error: (input) => `Value cannot start with 'test1', given ${input}.`
+      }]
+    );
+    const input = await textPrompt.question();
+    assert.deepEqual(input, "test2");
+    assert.deepEqual(logs, [
+      "? What's your name?",
+      "? What's your name? [Value cannot start with 'test1', given test1.]",
+      "? What's your name? [Value cannot start with 'test1', given test10.]",
+      "✔ What's your name? › test2"
+    ]);
+  });
 });


### PR DESCRIPTION
This PR add validators for `prompt` (useless in `select` & `confirm` as user cannot answer anything), I think we can do better (in this PR or in the future) for instance we may provide some default validators like `Required` or `Integer`.

Fixed bug where only one line was being deleted when a line written in the TTY exceeded the number of columns in the terminal, causing a line break. The fix ensures that the correct number of lines are now deleted.

Fixed an indentation bug & a double whitespace in `confirm`.