### PR TITLE
feat: add unicode fallback for unsupported terminals

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "Node.js user input library for command-line interfaces.",
   "scripts": {
-    "test": "node --loader=esmock --test ./test/**.test.js",
+    "test": "node --loader=esmock --test test/",
     "coverage": "c8 -r html npm run test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
@@ -29,7 +29,8 @@
     "esmock": "^2.1.0"
   },
   "dependencies": {
-    "ansi-styles": "^6.2.1",
+    "is-unicode-supported": "^1.3.0",
+    "kleur": "^4.1.5",
     "strip-ansi": "^7.0.1"
   },
   "engines": {

--- a/src/confirm-prompt.js
+++ b/src/confirm-prompt.js
@@ -2,7 +2,7 @@
 import { EOL } from "node:os";
 
 // Import Third-party Dependencies
-import ansi from "ansi-styles";
+import kleur from "kleur";
 
 // Import Internal Dependencies
 import { AbstractPrompt } from "./abstract-prompt.js";
@@ -17,9 +17,9 @@ export class ConfirmPrompt extends AbstractPrompt {
     } = options;
     super(message, stdin, stdout);
 
-    const Yes = `${ansi.bold.open}Yes${ansi.bold.close}`;
-    const No = `${ansi.bold.open}No${ansi.bold.close}`;
-    const tip = initial ? `${Yes}/no` : `yes/${No}`;
+    const Yes = kleur.bold("Yes");
+    const No = kleur.bold("No");
+    this.tip = kleur.gray(initial ? `(${Yes}/no)` : `(yes/${No})`);
 
     this.initial = initial;
   }
@@ -39,14 +39,14 @@ export class ConfirmPrompt extends AbstractPrompt {
   }
 
   #getQuestionQuery() {
-    const query = `${ansi.bold.open}${SYMBOLS.QuestionMark} ${this.message}${ansi.bold.close}`;
+    const query = kleur.bold(`${SYMBOLS.QuestionMark} ${this.message}`);
 
-    return `${query} ${ansi.grey.open}(${this.initial ? "Yes/no" : "yes/No"})${ansi.grey.close} `;
+    return `${query} ${this.tip} `;
   }
 
   #onQuestionAnswer() {
     this.clearLastLine();
-    this.write(`${this.answer ? SYMBOLS.Tick : SYMBOLS.Cross} ${this.message}${EOL}`);
+    this.write(`${this.answer ? SYMBOLS.Tick : SYMBOLS.Cross} ${kleur.bold(this.message)}${EOL}`);
   }
 
   #validateResult(result) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,17 +1,31 @@
 // Import Third-party Dependencies
-import ansi from "ansi-styles";
+import kleur from "kleur";
+import isUnicodeSupported from "is-unicode-supported";
 
-const kPointer = `${ansi.gray.open}›${ansi.gray.close}`;
+const kMainSymbols = {
+  tick: "✔",
+  cross: "✖",
+  pointer: "›",
+  previous: "⭡",
+  next: "⭣"
+};
+const kFallbackSymbols = {
+  tick: "√",
+  cross: "×",
+  pointer: ">",
+  previous: "↑",
+  next: "↓"
+};
+const kSymbols = isUnicodeSupported() ? kMainSymbols : kFallbackSymbols;
+const kPointer = kleur.gray(kSymbols.pointer);
 
 export const SYMBOLS = {
-  QuestionMark: `${ansi.blue.open}?${ansi.blue.close}`,
-  Tick: `${ansi.green.open}✔${ansi.green.close}`,
-  Cross: `${ansi.red.open}✖${ansi.red.close}`,
+  QuestionMark: kleur.blue().bold("?"),
+  Tick: kleur.green().bold(kSymbols.tick),
+  Cross: kleur.red().bold(kSymbols.cross),
   Pointer: kPointer,
-  Active: `${ansi.reset.open}${kPointer}`,
-  Inactive: `${ansi.gray.open}`,
-  Previous: "⭡",
-  Next: "⭣",
+  Previous: kSymbols.previous,
+  Next: kSymbols.next,
   ShowCursor: "\x1B[?25h",
   HideCursor: "\x1B[?25l"
 };

--- a/src/question-prompt.js
+++ b/src/question-prompt.js
@@ -2,8 +2,7 @@
 import { EOL } from "node:os";
 
 // Import Third-party Dependencies
-import ansi from "ansi-styles";
-import stripAnsi from "strip-ansi";
+import kleur from "kleur";
 
 // Import Internal Dependencies
 import { AbstractPrompt } from "./abstract-prompt.js";
@@ -17,8 +16,6 @@ export class QuestionPrompt extends AbstractPrompt {
     super(message, stdin, stdout);
 
     this.#validators = validators;
-    this.questionPrefix = `${ansi.bold.open}${SYMBOLS.QuestionMark} `;
-    this.questionSuffix = `${ansi.bold.close} `;
     this.questionSuffixError = "";
   }
 
@@ -35,19 +32,19 @@ export class QuestionPrompt extends AbstractPrompt {
   }
 
   #getQuestionQuery() {
-    return `${this.questionPrefix}${this.message}${this.questionSuffix}${this.questionSuffixError}`;
+    return `${kleur.bold(`${SYMBOLS.QuestionMark} ${this.message}`)} ${this.questionSuffixError}`;
   }
 
   #setQuestionSuffixError(error) {
-    const suffix = `${ansi.red.open}[${error}]${ansi.red.close} `;
+    const suffix = kleur.red(`[${error}] `);
     this.questionSuffixError = suffix;
   }
 
   #writeAnswer() {
-    const prefix = `${ansi.bold.open}${this.answer ? SYMBOLS.Tick : SYMBOLS.Cross}`;
-    const suffix = `${ansi.yellow.close}${ansi.bold.close}${EOL}`;
+    const prefix = this.answer ? SYMBOLS.Tick : SYMBOLS.Cross;
+    const answer = kleur.yellow(this.answer ?? "");
 
-    this.write(`${prefix} ${this.message} ${SYMBOLS.Pointer} ${ansi.yellow.open}${this.answer ?? ""}${suffix}`);
+    this.write(`${prefix} ${kleur.bold(this.message)} ${SYMBOLS.Pointer} ${answer}${EOL}`);
   }
 
   #onQuestionAnswer() {

--- a/src/select-prompt.js
+++ b/src/select-prompt.js
@@ -2,7 +2,7 @@
 import { EOL } from "node:os";
 
 // Import Third-party Dependencies
-import ansi from "ansi-styles";
+import kleur from "kleur";
 
 // Import Internal Dependencies
 import { AbstractPrompt } from "./abstract-prompt.js";
@@ -82,6 +82,7 @@ export class SelectPrompt extends AbstractPrompt {
 
     for (let choiceIndex = startIndex; choiceIndex < endIndex; choiceIndex++) {
       const choice = this.#getFormattedChoice(choiceIndex);
+      const isChoiceSelected = choiceIndex === this.activeIndex;
       const showPreviousChoicesArrow = startIndex > 0 && choiceIndex === startIndex;
       const showNextChoicesArrow = endIndex < this.choices.length && choiceIndex === endIndex - 1;
 
@@ -93,20 +94,21 @@ export class SelectPrompt extends AbstractPrompt {
         prefixArrow = SYMBOLS.Next;
       }
 
-      const prefix = `${prefixArrow}${choiceIndex === this.activeIndex ? `${SYMBOLS.Active} ` : `${SYMBOLS.Inactive}  `}`;
+      const prefix = `${prefixArrow}${isChoiceSelected ? `${SYMBOLS.Pointer} ` : "  "}`;
       const formattedLabel = choice.label.padEnd(
         this.longestChoice < 10 ? this.longestChoice : 0
       );
       const formattedDescription = choice.description ? ` - ${choice.description}` : "";
-      const str = `${prefix}${formattedLabel}${formattedDescription}${ansi.reset.open}${EOL}`;
+      const color = isChoiceSelected ? kleur.white().bold : kleur.gray;
+      const str = color(`${prefix}${formattedLabel}${formattedDescription}${EOL}`);
 
       this.write(str);
     }
   }
 
   #showAnsweredQuestion(choice) {
-    const prefix = `${ansi.bold.open}${SYMBOLS.Tick} ${this.message} ${SYMBOLS.Pointer}`;
-    const formattedChoice = `${ansi.yellow.open}${choice.label ?? choice}${ansi.reset.open}`;
+    const prefix = `${SYMBOLS.Tick} ${kleur.bold(this.message)} ${SYMBOLS.Pointer}`;
+    const formattedChoice = kleur.yellow(choice.label ?? choice);
 
     this.write(`${prefix} ${formattedChoice}${EOL}`);
   }
@@ -175,6 +177,6 @@ export class SelectPrompt extends AbstractPrompt {
   }
 
   #showQuestion() {
-    this.write(`${ansi.bold.open}${SYMBOLS.QuestionMark} ${this.message}${ansi.bold.close}${EOL}`);
+    this.write(`${SYMBOLS.QuestionMark} ${kleur.bold(this.message)}${EOL}`);
   }
 }


### PR DESCRIPTION
This PR also introduce a refactor: migrating from `ansi-styles` to `kleur` but it was a bit annoying to introduce 2 commits.

Note: now the Tick & Cross symbols are bold as it render much better:
![image](https://github.com/TopCli/prompts/assets/39910767/22a4e879-4b3d-45c2-b1ac-fe9c5c106654)

You can see the diff on this screen, FYI the non-bold tick symbol on this screen is displayed by `@topcli/spinner`, i think it could be nice to make it bold in this package also, or at least to provide an option to allow it, WDYT @fraxken ?
