### PR TITLE
feat(question): add default value option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Boolean prompt, return `options.initial` if user input is different from "y"/"ye
 
 ```ts
 export interface PromptOptions {
+  defaultValue?: string;
   validators?: {
     validate: (input: string) => boolean;
     error: (input: string) => string;

--- a/demo.js
+++ b/demo.js
@@ -2,7 +2,7 @@ import { question, confirm, select } from "./index.js";
 
 const kTestRunner = ["node", "tap", "tape", "vitest", "mocha", "ava"];
 
-const name = await question("Project name ?");
+const name = await question("Project name ?", { defaultValue: "foo" });
 const runner = await select("Choose a test runner", { choices: kTestRunner, maxVisible: 5 });
 const isCLI = await confirm("Your project is a CLI ?", { initial: true });
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 export interface PromptOptions {
+  defaultValue?: string;
   validators?: Validator[];
 }
 

--- a/src/question-prompt.js
+++ b/src/question-prompt.js
@@ -12,9 +12,21 @@ export class QuestionPrompt extends AbstractPrompt {
   #validators;
 
   constructor(message, options = {}) {
-    const { stdin = process.stdin, stdout = process.stdout, validators = [] } = options;
+    const {
+      stdin = process.stdin,
+      stdout = process.stdout,
+      defaultValue,
+      validators = []
+    } = options;
+
     super(message, stdin, stdout);
 
+    if (defaultValue && typeof defaultValue !== "string") {
+      throw new TypeError("defaultValue must be a string");
+    }
+
+    this.defaultValue = defaultValue;
+    this.tip = this.defaultValue ? ` (${this.defaultValue})` : "";
     this.#validators = validators;
     this.questionSuffixError = "";
   }
@@ -32,7 +44,7 @@ export class QuestionPrompt extends AbstractPrompt {
   }
 
   #getQuestionQuery() {
-    return `${kleur.bold(`${SYMBOLS.QuestionMark} ${this.message}`)} ${this.questionSuffixError}`;
+    return `${kleur.bold(`${SYMBOLS.QuestionMark} ${this.message}${this.tip}`)} ${this.questionSuffixError}`;
   }
 
   #setQuestionSuffixError(error) {
@@ -65,6 +77,10 @@ export class QuestionPrompt extends AbstractPrompt {
 
   async question() {
     this.answer = await this.#question();
+
+    if (this.answer === "" && this.defaultValue) {
+      this.answer = this.defaultValue;
+    }
 
     this.#onQuestionAnswer();
 

--- a/test/helpers/testing-prompt.js
+++ b/test/helpers/testing-prompt.js
@@ -7,7 +7,7 @@ import { mockProcess } from "./mock-process.js";
 
 export class TestingPrompt {
   static async QuestionPrompt(message, options) {
-    const { input, onStdoutWrite, validators } = options;
+    const { input, onStdoutWrite, defaultValue, validators } = options;
     const inputs = Array.isArray(input) ? input : [input];
 
     const { QuestionPrompt } = await esmock("../../src/question-prompt", { }, {
@@ -25,7 +25,7 @@ export class TestingPrompt {
     });
     const { stdin, stdout } = mockProcess([], (data) => onStdoutWrite(data));
 
-    return new QuestionPrompt(message, { stdin, stdout, validators });
+    return new QuestionPrompt(message, { stdin, stdout, defaultValue, validators });
   }
 
   static async SelectPrompt(message, options) {

--- a/test/question-prompt.test.js
+++ b/test/question-prompt.test.js
@@ -76,4 +76,32 @@ describe("QuestionPrompt", () => {
       "✔ What's your name? › toto"
     ]);
   });
+
+  it("should return the default value", async() => {
+    const logs = [];
+    const questionPrompt = await TestingPrompt.QuestionPrompt("What's your name?", {
+      input: [""],
+      defaultValue: "John Doe",
+      onStdoutWrite: (log) => logs.push(log)
+    });
+    const input = await questionPrompt.question();
+
+    assert.equal(input, "John Doe");
+    assert.deepStrictEqual(logs, [
+      "? What's your name? (John Doe)",
+      "✔ What's your name? › John Doe"
+    ]);
+  });
+
+  it("should throw when given defaultValue is not a string", async() => {
+    await assert.rejects(async() => {
+      await TestingPrompt.QuestionPrompt("What's your name?", {
+        input: [""],
+        defaultValue: { foo: "bar" }
+      });
+    }, {
+      name: "TypeError",
+      message: "defaultValue must be a string"
+    });
+  });
 });


### PR DESCRIPTION
This PR will allow to replace this:

```js
const filename = await question(`Enter the filename (${defaultFilename})`) || defaultFilename;
```

With this

```js
const filename = await question("Enter the filename", { defaultValue: defaultFilename});
```