### PR TITLE
feat: add PromptAgent to programmatically set answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![isc](https://img.shields.io/badge/License-ISC-blue.svg?style=for-the-badge)](https://github.com/TopCli/prompts/blob/main/LICENSE)
 ![build](https://img.shields.io/github/actions/workflow/status/TopCli/prompts/node.js.yml?style=for-the-badge)
 
-Node.js user input library for command-line interfaces.
+Node.js user prompt library for command-line interfaces.
 
 ## Requirements
-- [Node.js](https://nodejs.org/en/) v14 or higher
+- [Node.js](https://nodejs.org/en/) v16 or higher
 
 ## Getting Started
 
@@ -89,38 +89,64 @@ Use `ignoreValues` to skip result render & clear lines after a selected one.
 confirm(message: string, options?: ConfirmOptions): Promise<boolean>
 ```
 
-Boolean prompt, return `options.initial` if user input is different from "y"/"yes"/"n"/"no", (default `false`).
+Boolean prompt, return `options.initial` if user input is different from `y`/`yes`/`n`/`no` (case insensitive), (default `false`).
+
+### `PromptAgent`
+
+The `PromptAgent` class allows to programmatically set the next answers for any prompt function, this can be useful for testing.
+
+```ts
+const agent = PromptAgent.agent();
+agent.nextAnswer("John");
+
+const input = await question("What's your name?");
+assert.equal(input, "John");
+```
+
+> [!WARNING]
+> Answers set with `PromptAgent` will **bypass** any logical & validation rules.
+> Examples:
+> - When using `question()`, `validators` functions will not be executed.
+> - When using `select()`, the answer can be different from the available choices.
+> - When using `confirm()`, the answer can be any type other than boolean.
+> **Use with caution**
 
 ## Interfaces
 
 ```ts
-export interface PromptOptions {
-  defaultValue?: string;
-  validators?: {
-    validate: (input: string) => boolean;
-    error: (input: string) => string;
-  }[];
+export interface SharedOptions {
+  stdin?: NodeJS.ReadStream & {
+    fd: 0;
+  };
+  stdout?: NodeJS.WriteStream & {
+    fd: 1;
+  };
 }
-```
-```ts
+
+export interface Validator {
+  validate: (input: string) => boolean;
+  error: (input?: string) => string;
+}
+
+export interface QuestionOptions extends SharedOptions {
+  defaultValue?: string;
+  validators?: Validator[];
+}
+
 export interface Choice {
   value: any;
   label: string;
   description?: string;
 }
-```
 
-```ts
-export interface SelectOptions {
+export interface SelectOptions extends SharedOptions  {
   choices: (Choice | string)[];
-  maxVisible?: number = 8;
+  maxVisible?: number;
   ignoreValues?: (string | number | boolean)[];
 }
-```
 
-```ts
-export interface ConfirmOptions {
-  initial?: boolean = false;
+export interface ConfirmOptions extends SharedOptions  {
+  initial?: boolean;
 }
 ```
 

--- a/demo.js
+++ b/demo.js
@@ -1,4 +1,4 @@
-import { question, confirm, select } from "./index.js";
+import { question, confirm, select, PromptAgent } from "./index.js";
 
 const kTestRunner = ["node", "tap", "tape", "vitest", "mocha", "ava"];
 
@@ -7,3 +7,12 @@ const runner = await select("Choose a test runner", { choices: kTestRunner, maxV
 const isCLI = await confirm("Your project is a CLI ?", { initial: true });
 
 console.log(name, runner, isCLI);
+
+const agent = PromptAgent.agent();
+agent.nextAnswer(["toto", "tap", false]);
+
+const _name = await question("Project name ?", { defaultValue: "foo" });
+const _runner = await select("Choose a test runner", { choices: kTestRunner, maxVisible: 5 });
+const _isCLI = await confirm("Your project is a CLI ?", { initial: true });
+
+console.log(_name, _runner, _isCLI);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,10 @@
-export interface QuestionOptions {
+export interface SharedOptions {
   stdin?: NodeJS.ReadStream & {
     fd: 0;
   };
   stdout?: NodeJS.WriteStream & {
     fd: 1;
   };
-  defaultValue?: string;
-  validators?: Validator[];
 }
 
 export interface Validator {
@@ -14,19 +12,25 @@ export interface Validator {
   error: (input?: string) => string;
 }
 
+export interface QuestionOptions extends SharedOptions {
+  defaultValue?: string;
+  validators?: Validator[];
+}
+
+
 export interface Choice {
   value: any;
   label: string;
   description?: string;
 }
 
-export interface SelectOptions {
+export interface SelectOptions extends SharedOptions  {
   choices: (Choice | string)[];
   maxVisible?: number;
   ignoreValues?: (string | number | boolean)[];
 }
 
-export interface ConfirmOptions {
+export interface ConfirmOptions extends SharedOptions  {
   initial?: boolean;
 }
 
@@ -35,3 +39,29 @@ export function select(message: string, options: SelectOptions): Promise<string>
 export function confirm(message: string, options?: ConfirmOptions): Promise<boolean>;
 
 export function required(): Validator;
+
+export class PromptAgent {
+  /**
+   * The prompts answers queue.
+   * When not empty, any prompt will be answered by the first answer in this list.
+   */
+  nextAnswers: Array<string | boolean>;
+
+  static get agent(): PromptAgent;
+
+  /**
+   * Programmatically set the next answer for any prompt (`question()`, `confirm()`, `select()`)
+   *
+   * This is useful for testing.
+   *
+   * @example
+   * ```js
+   * const promptAgent = PromptAgent.agent();
+   * promptAgent.nextAnswer("toto");
+   *
+   * const input = await question("what is your name?");
+   * assert.equal(input, "toto");
+   * ```
+   */
+  nextAnswer(value: string | boolean | Array<string | boolean>): void
+}

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import { ConfirmPrompt } from "./src/confirm-prompt.js";
 import { SelectPrompt } from "./src/select-prompt.js";
 import { QuestionPrompt } from "./src/question-prompt.js";
 import { required } from "./src/validators.js";
+import { PromptAgent } from "./src/prompt-agent.js";
 
 export async function question(message, options = {}) {
   const questionPrompt = new QuestionPrompt(message, options);
@@ -22,4 +23,4 @@ export async function confirm(message, options) {
   return confirmPrompt.confirm();
 }
 
-export { required };
+export { required, PromptAgent };

--- a/src/abstract-prompt.js
+++ b/src/abstract-prompt.js
@@ -5,6 +5,9 @@ import { createInterface } from "node:readline";
 // Import Third-party Dependencies
 import stripAnsi from "strip-ansi";
 
+// Import Internal Dependencies
+import { PromptAgent } from "./prompt-agent.js";
+
 export class AbstractPrompt {
   constructor(message, input = process.stdin, output = process.stdout) {
     if (this.constructor === AbstractPrompt) {
@@ -19,6 +22,7 @@ export class AbstractPrompt {
     this.stdout = output;
     this.message = message;
     this.history = [];
+    this.agent = PromptAgent.agent();
 
     if (this.stdout.isTTY) {
       this.stdin.setRawMode(true);

--- a/src/confirm-prompt.js
+++ b/src/confirm-prompt.js
@@ -98,6 +98,15 @@ export class ConfirmPrompt extends AbstractPrompt {
   }
 
   async confirm() {
+    if (this.agent.nextAnswers.length > 0) {
+      const answer = this.agent.nextAnswers.shift();
+      this.selectedValue = answer;
+      this.#onQuestionAnswer();
+      this.destroy();
+
+      return answer;
+    }
+
     this.write(SYMBOLS.HideCursor);
 
     try {

--- a/src/prompt-agent.js
+++ b/src/prompt-agent.js
@@ -1,0 +1,56 @@
+// CONSTANTS
+const kPrivateInstancier = Symbol("instancier");
+
+export class PromptAgent {
+  /**
+   * The prompts answers queue.
+   * When not empty, any prompt will be answered by the first answer in this list.
+   *
+   *  @type {string[]}
+   */
+  nextAnswers = [];
+
+  /**
+   * The shared PromptAgent.
+   *
+   * @type {PromptAgent}
+   */
+  static #this;
+
+  static agent() {
+    // eslint-disable-next-line no-return-assign
+    return this.#this ??= new PromptAgent(kPrivateInstancier);
+  }
+
+  constructor(instancier) {
+    if (instancier !== kPrivateInstancier) {
+      throw new Error("Cannot instanciate PromptAgent, use PromptAgent.agent() instead");
+    }
+  }
+
+  /**
+   * Programmatically set the next answer for any prompt (`question()`, `confirm()`, `select()`)
+   *
+   * This is useful for testing.
+   *
+   * @param {string | boolean | Array<string | boolean>} value
+   *
+   * @example
+   * ```js
+   * const promptAgent = PromptAgent.agent();
+   * promptAgent.nextAnswer("toto");
+   *
+   * const input = await question("what is your name?");
+   * assert.equal(input, "toto");
+   * ```
+   */
+  nextAnswer(value) {
+    if (Array.isArray(value)) {
+      this.nextAnswers.push(...value);
+
+      return;
+    }
+
+    this.nextAnswers.push(value);
+  }
+}

--- a/src/question-prompt.js
+++ b/src/question-prompt.js
@@ -76,6 +76,14 @@ export class QuestionPrompt extends AbstractPrompt {
   }
 
   async question() {
+    if (this.agent.nextAnswers.length > 0) {
+      this.answer = this.agent.nextAnswers.shift();
+      this.#writeAnswer();
+      this.destroy();
+
+      return this.answer;
+    }
+
     this.answer = await this.#question();
 
     if (this.answer === "" && this.defaultValue) {

--- a/src/select-prompt.js
+++ b/src/select-prompt.js
@@ -114,6 +114,14 @@ export class SelectPrompt extends AbstractPrompt {
   }
 
   async select() {
+    if (this.agent.nextAnswers.length > 0) {
+      const answer = this.agent.nextAnswers.shift();
+      this.#showAnsweredQuestion(answer);
+      this.destroy();
+
+      return answer;
+    }
+
     this.write(SYMBOLS.HideCursor);
     this.#showQuestion();
 

--- a/test/confirm-prompt.test.js
+++ b/test/confirm-prompt.test.js
@@ -5,6 +5,9 @@ import { describe, it } from "node:test";
 // Import Internal Dependencies
 import { ConfirmPrompt } from "../src/confirm-prompt.js";
 import { TestingPrompt } from "./helpers/testing-prompt.js";
+import { confirm } from "../index.js";
+import { mockProcess } from "./helpers/mock-process.js";
+import { PromptAgent } from "../src/prompt-agent.js";
 
 // CONSTANTS
 const kInputs = {
@@ -21,6 +24,7 @@ const kInputs = {
   space: { name: "space" },
   return: { name: "return" }
 };
+const kPromptAgent = PromptAgent.agent();
 
 describe("ConfirmPrompt", () => {
   it("message should be required", async() => {
@@ -96,4 +100,30 @@ describe("ConfirmPrompt", () => {
       ]);
     });
   }
+
+  it("should return the answer (true) set via PromptAgent", async() => {
+    const logs = [];
+    const { stdin, stdout } = mockProcess([], (text) => logs.push(text));
+    kPromptAgent.nextAnswer(true);
+
+    const input = await confirm("Foo", { stdin, stdout });
+
+    assert.equal(input, true);
+    assert.deepStrictEqual(logs, [
+      "✔ Foo"
+    ]);
+  });
+
+  it("should return the answer (false) set via PromptAgent", async() => {
+    const logs = [];
+    const { stdin, stdout } = mockProcess([], (text) => logs.push(text));
+    kPromptAgent.nextAnswer(false);
+
+    const input = await confirm("Foo", { stdin, stdout });
+
+    assert.equal(input, false);
+    assert.deepStrictEqual(logs, [
+      "✖ Foo"
+    ]);
+  });
 });

--- a/test/helpers/mock-process.js
+++ b/test/helpers/mock-process.js
@@ -24,7 +24,9 @@ export function mockProcess(inputs, writeCb) {
     },
     off: () => true,
     pause: () => true,
-    paused: () => false
+    paused: () => false,
+    resume: () => true,
+    removeListener: () => true
   };
 
   return { stdout, stdin };

--- a/test/question-prompt.test.js
+++ b/test/question-prompt.test.js
@@ -6,6 +6,12 @@ import { describe, it } from "node:test";
 import { QuestionPrompt } from "../src/question-prompt.js";
 import { TestingPrompt } from "./helpers/testing-prompt.js";
 import { required } from "../src/validators.js";
+import { PromptAgent } from "../src/prompt-agent.js";
+import { question } from "../index.js";
+import { mockProcess } from "./helpers/mock-process.js";
+
+// CONSTANTS
+const kPromptAgent = PromptAgent.agent();
 
 describe("QuestionPrompt", () => {
   it("message should be string", async() => {
@@ -14,28 +20,26 @@ describe("QuestionPrompt", () => {
 
   it("should render with tick on valid input", async() => {
     const logs = [];
-    const questionPrompt = await TestingPrompt.QuestionPrompt("What's your name?", {
-      input: "Joe",
-      onStdoutWrite: (log) => logs.push(log)
-    });
-    const input = await questionPrompt.question();
+    const { stdin, stdout } = mockProcess([], (text) => logs.push(text));
+    kPromptAgent.nextAnswer("Joe");
+
+    const input = await question("What's your name?", { stdin, stdout });
+
     assert.equal(input, "Joe");
     assert.deepStrictEqual(logs, [
-      "? What's your name?",
       "✔ What's your name? › Joe"
     ]);
   });
 
   it("should render cross on invalid input", async() => {
     const logs = [];
-    const questionPrompt = await TestingPrompt.QuestionPrompt("What's your name?", {
-      input: undefined,
-      onStdoutWrite: (log) => logs.push(log)
-    });
-    const input = await questionPrompt.question();
+    const { stdin, stdout } = mockProcess([], (text) => logs.push(text));
+    kPromptAgent.nextAnswer(undefined);
+
+    const input = await question("What's your name?", { stdin, stdout });
+
     assert.strictEqual(input, undefined);
     assert.deepStrictEqual(logs, [
-      "? What's your name?",
       "✖ What's your name? › "
     ]);
   });

--- a/test/select-prompt.test.js
+++ b/test/select-prompt.test.js
@@ -5,11 +5,15 @@ import { describe, it } from "node:test";
 // Import Internal Dependencies
 import { SelectPrompt } from "../src/select-prompt.js";
 import { TestingPrompt } from "./helpers/testing-prompt.js";
+import { mockProcess } from "./helpers/mock-process.js";
+import { PromptAgent } from "../src/prompt-agent.js";
+import { select } from "../index.js";
 
 const kInputs = {
   down: { name: "down" },
   return: { name: "return" }
 };
+const kPromptAgent = PromptAgent.agent();
 
 describe("SelectPrompt", () => {
   it("message should be required", () => {
@@ -380,5 +384,26 @@ describe("SelectPrompt", () => {
       "✔ Choose option › one"
     ]);
     assert.equal(input, "option1");
+  });
+
+  it("should return the answer set via PromptAgent", async() => {
+    const logs = [];
+    const { stdin, stdout } = mockProcess([], (text) => logs.push(text));
+    kPromptAgent.nextAnswer("option1");
+
+    const options = {
+      choices: [
+        { value: "option1", label: "one", description: "foo" },
+        { value: "option2", label: "Option 2", description: "foo" },
+        { value: "option3", label: "Option three", description: "foo" }
+      ],
+      maxVisible: 5
+    };
+    const input = await select("Choose option", { ...options, stdin, stdout });
+
+    assert.equal(input, "option1");
+    assert.deepStrictEqual(logs, [
+      "✔ Choose option › option1"
+    ]);
   });
 });


### PR DESCRIPTION
This PR fixes #31 

The initial idea was to use `EventEmitter`, inspired from the [linked](https://github.com/poppinss/prompts/blob/develop/test/prompt.spec.ts?rgh-link-date=2023-07-13T21%3A51%3A22Z) project.

But it look like it was easier to simply use an "Agent" to allows to programmatically set answers (the implementation is much easier)

Theses changes should help people testing their CLI when using `@topcli/prompts`