### PR TITLE
fix: frozen subsequent select after using confirm

### DIFF
--- a/src/confirm-prompt.js
+++ b/src/confirm-prompt.js
@@ -65,9 +65,8 @@ export class ConfirmPrompt extends AbstractPrompt {
   }
 
   #onKeypress(resolve, value, key) {
-    this.stdin.pause();
     this.stdout.moveCursor(-this.#getQuestionQuery().length, 0);
-    this.stdout.clearScreenDown(() => this.stdin.resume());
+    this.stdout.clearScreenDown();
 
     if (key.name === "return") {
       resolve(this.selectedValue);


### PR DESCRIPTION
Hi, these changes fix a weird bug: when using `confirm` then multiple `select`, each n+1 `select` is frozen.

Reproduction:
```js
import { confirm, select } from "@topcli/prompts";

await confirm("foo");
await select("foo", { choices: ["foo", "bar"] });
await select("foo", { choices: ["foo", "bar"] }); // Frozen / locked, we need to press ENTER to unlock it then stdout if messed up
```

I don't have explanations, neither why this bug happens nor why these changes solve it... But I've tested multiple things with Node v18 & v20, theses changes don't break anything and everything looks fine now.