### PR TITLE
fix(confirm): clear the right amount of line

### DIFF
--- a/src/prompts/confirm.ts
+++ b/src/prompts/confirm.ts
@@ -119,10 +119,10 @@ export class ConfirmPrompt extends AbstractPrompt<boolean> {
   }
 
   #onQuestionAnswer() {
-    const defaultLines = this.fastAnswer ? 0 : 1;
+    this.clearLastLine();
     this.stdout.moveCursor(
       -this.stdout.columns,
-      -(Math.floor(wcwidth(stripAnsi(this.#getQuestionQuery())) / this.stdout.columns) || defaultLines)
+      -Math.floor(wcwidth(stripAnsi(this.#getQuestionQuery())) / this.stdout.columns)
     );
     this.stdout.clearScreenDown();
     this.write(`${this.selectedValue ? SYMBOLS.Tick : SYMBOLS.Cross} ${kleur.bold(this.message)}${EOL}`);


### PR DESCRIPTION
As discussed here: https://github.com/TopCli/prompts/pull/93#issuecomment-1939531874

The `const defaultLines = this.fastAnswer ? 0 : 1;` was working only if we had only one confirm prompt.
If we had multiple confirm prompts then it cleared an excess one.

The `clearLastLine` handle it if there is no line to clear (for instance when using `PromptAgent`)

