### PR TITLE
feat(select): validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ select(message: string, options: SelectOptions): Promise<string>
 ```
 
 Scrollable select depending `maxVisible` (default `8`).
+
 Use `ignoreValues` to skip result render & clear lines after a selected one.
+
+Use `validators` to handle user input.
 
 Use `autocomplete` to allow filtered choices. This can be useful for a large list of choices.
 
@@ -178,6 +181,7 @@ export interface SelectOptions extends SharedOptions  {
   choices: (Choice | string)[];
   maxVisible?: number;
   ignoreValues?: (string | number | boolean)[];
+  validators?: Validator[];
   autocomplete?: boolean;
   caseSensitive?: boolean;
 }


### PR DESCRIPTION
With #93 we made the first iteration to have the same functionality as in the `multiselect` prompt.

This PR adds the possibility to define validations for the `select` prompt.

Currently only `required` exists as built-in validation - The testcase is using this validation to make sure everything works as expected.

**When is this useful?**

If you don't use `autocomplete: true` the current index will be used as value if you press `<enter>`.
But if you have `autocomplete` enabled, it's possible to filter until you get an empty list.

By default, the `select`prompt will return an empty value ( `""` ).
If this is not what you want, you can now add a validation to make sure you get a valid value. 

- [x] Updated the docs
- [x] Updated the test case  