### PR TITLE
fix: prevent non-TTY terminals from crashing

### DIFF
--- a/src/prompts/abstract.ts
+++ b/src/prompts/abstract.ts
@@ -53,6 +53,14 @@ export class AbstractPrompt<T> extends EventEmitter {
       throw new TypeError(`message must be string, ${typeof message} given.`);
     }
 
+    if (!output.isTTY) {
+      // when process.stdout is not TTY (i.e within IDEs) theses methods does not exists and make the lib crashing
+      Object.assign(output, {
+        moveCursor: () => void 0,
+        clearScreenDown: () => void 0,
+      })
+    }
+
     this.stdin = input;
     this.stdout = output;
     this.message = message;


### PR DESCRIPTION
Note: this is not sexy but i think its simpler than adding dozens of `if (this.stdout.isTTY)` everywhere in the codebase 😄 