### PR TITLE
feat: add skip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,15 @@ question(message: string, options?: PromptOptions): Promise<string>
 
 Simple prompt, similar to `rl.question()` with an improved UI.
 
+Use `options.defaultValue` to set a default value.
+
 Use `options.secure` if you need to hide both input and answer.
 
 Use `options.signal` to set an `AbortSignal` (throws a [AbortError](#aborterror)).
 
 Use `options.validators` to handle user input.
+
+Use `options.skip` to skip prompt. It will return `options.defaultValue` if given, `""` otherwise.
 
 **Example**
 
@@ -95,15 +99,17 @@ select(message: string, options: SelectOptions): Promise<string>
 
 Scrollable select depending `maxVisible` (default `8`).
 
-Use `ignoreValues` to skip result render & clear lines after a selected one.
+Use `options.ignoreValues` to skip result render & clear lines after a selected one.
 
-Use `validators` to handle user input.
+Use `options.validators` to handle user input.
 
-Use `autocomplete` to allow filtered choices. This can be useful for a large list of choices.
+Use `options.autocomplete` to allow filtered choices. This can be useful for a large list of choices.
 
-Use `caseSensitive` to make autocomplete filters case sensitive. Default `false`
+Use `options.caseSensitive` to make autocomplete filters case sensitive. Default `false`
 
 Use `options.signal` to set an `AbortSignal` (throws a [AbortError](#aborterror)).
+
+Use `options.skip` to skip prompt. It will return the first choice.
 
 ### `multiselect()`
 
@@ -111,18 +117,20 @@ Use `options.signal` to set an `AbortSignal` (throws a [AbortError](#aborterror)
 multiselect(message: string, options: MultiselectOptions): Promise<[string]>
 ```
 
-Scrollable multiselect depending `maxVisible` (default `8`).<br>
-Use `preSelectedChoices` to pre-select choices.
+Scrollable multiselect depending `options.maxVisible` (default `8`).<br>
+Use `options.preSelectedChoices` to pre-select choices.
 
-Use `validators` to handle user input.
+Use `options.validators` to handle user input.
 
-Use `showHint: false` to disable hint (this option is truthy by default).
+Use `options.showHint: false` to disable hint (this option is truthy by default).
 
-Use `autocomplete` to allow filtered choices. This can be useful for a large list of choices.
+Use `options.autocomplete` to allow filtered choices. This can be useful for a large list of choices.
 
-Use `caseSensitive` to make autocomplete filters case sensitive. Default `false`.
+Use `options.caseSensitive` to make autocomplete filters case sensitive. Default `false`.
 
 Use `options.signal` to set an `AbortSignal` (throws a [AbortError](#aborterror)).
+
+Use `options.skip` to skip prompt. It will return `options.preSelectedChoices` if given, `[]` otherwise.
 
 ### `confirm()`
 
@@ -136,6 +144,8 @@ Boolean prompt, default to `options.initial` (`false`).
 > You can answer pressing <kbd>Y</kbd> or <kbd>N</kbd>
 
 Use `options.signal` to set an `AbortSignal` (throws a [AbortError](#aborterror)).
+
+Use `options.skip` to skip prompt. It will return `options.initial` (`false` by default)
 
 ### `PromptAgent`
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,11 @@
 import { typescriptConfig } from "@openally/config.eslint";
 
-export default typescriptConfig();
+export default typescriptConfig([{
+  files: ["demo.js"],
+  rules: {
+    // Since we use TS linter, it mark `console` as undefined
+    "no-undef": "off"
+  }
+}, {
+  ignores: [".temp/**"],
+}]);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepublishOnly": "npm run build",
     "test": "glob -c \"tsx --no-warnings=ExperimentalWarning --loader=esmock --test\" \"./test/**/*.test.ts\"",
     "coverage": "c8 -r html npm run test",
-    "lint": "eslint .",
+    "lint": "eslint src test",
     "lint:fix": "eslint . --fix"
   },
   "main": "./dist/index.js",
@@ -31,7 +31,7 @@
   "license": "ISC",
   "type": "module",
   "devDependencies": {
-    "@openally/config.eslint": "^1.1.0",
+    "@openally/config.eslint": "^1.3.0",
     "@openally/config.typescript": "^1.0.3",
     "@types/node": "^22.10.5",
     "c8": "^10.1.3",

--- a/src/prompts/abstract.ts
+++ b/src/prompts/abstract.ts
@@ -21,6 +21,7 @@ export interface AbstractPromptOptions {
   stdin?: Stdin;
   stdout?: Stdout;
   message: string;
+  skip?: boolean;
   signal?: AbortSignal;
 }
 
@@ -29,6 +30,7 @@ export class AbstractPrompt<T> extends EventEmitter {
   stdout: Stdout;
   message: string;
   signal?: AbortSignal;
+  skip: boolean;
   history: string[];
   agent: PromptAgent<T>;
   mute: boolean;
@@ -46,7 +48,8 @@ export class AbstractPrompt<T> extends EventEmitter {
       stdin: input = process.stdin,
       stdout: output = process.stdout,
       message,
-      signal
+      signal,
+      skip = false
     } = options;
 
     if (typeof message !== "string") {
@@ -65,6 +68,7 @@ export class AbstractPrompt<T> extends EventEmitter {
     this.stdout = output;
     this.message = message;
     this.signal = signal;
+    this.skip = skip;
     this.history = [];
     this.agent = PromptAgent.agent<T>();
     this.mute = false;

--- a/src/prompts/confirm.ts
+++ b/src/prompts/confirm.ts
@@ -73,7 +73,7 @@ export class ConfirmPrompt extends AbstractPrompt<boolean> {
     });
   }
 
-  #onKeypress(resolve: (value: unknown) => void, value: any, key: Key) {
+  #onKeypress(resolve: (value: unknown) => void, _value: any, key: Key) {
     this.stdout.moveCursor(
       -this.stdout.columns,
       -Math.floor(wcwidth(stripAnsi(this.#getQuestionQuery())) / this.stdout.columns)
@@ -126,7 +126,13 @@ export class ConfirmPrompt extends AbstractPrompt<boolean> {
     this.write(`${this.selectedValue ? SYMBOLS.Tick : SYMBOLS.Cross} ${styleText("bold", this.message)}${EOL}`);
   }
 
-  confirm(): Promise<boolean> {
+  async confirm(): Promise<boolean> {
+    if (this.skip) {
+      this.destroy();
+
+      return this.initial;
+    }
+
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async(resolve, reject) => {
       const answer = this.agent.nextAnswers.shift();

--- a/src/prompts/question.ts
+++ b/src/prompts/question.ts
@@ -100,7 +100,13 @@ export class QuestionPrompt extends AbstractPrompt<string> {
     this.#writeAnswer();
   }
 
-  question(): Promise<string> {
+  async question(): Promise<string> {
+    if (this.skip) {
+      this.destroy();
+
+      return this.defaultValue ?? "";
+    }
+
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async(resolve, reject) => {
       this.answer = this.agent.nextAnswers.shift();

--- a/src/prompts/select.ts
+++ b/src/prompts/select.ts
@@ -238,7 +238,14 @@ export class SelectPrompt extends AbstractPrompt<string> {
     }
   }
 
-  select(): Promise<string> {
+  async select(): Promise<string> {
+    if (this.skip) {
+      this.destroy();
+      const answer = this.options.choices[0];
+
+      return typeof answer === "string" ? answer : answer.value;
+    }
+
     return new Promise((resolve, reject) => {
       const answer = this.agent.nextAnswers.shift();
       if (answer !== undefined) {

--- a/test/confirm-prompt.test.ts
+++ b/test/confirm-prompt.test.ts
@@ -179,4 +179,22 @@ describe("ConfirmPrompt", () => {
       "✖ Foo"
     ]);
   });
+
+  it("should return initial value (true) when skipping prompt", async() => {
+    const input = await confirm("Foo", {
+      skip: true,
+      initial: true
+    });
+
+    assert.strictEqual(input, true);
+  });
+
+  it("should return initial value (false) when skipping prompt", async() => {
+    const input = await confirm("Foo", {
+      skip: true,
+      initial: false
+    });
+
+    assert.strictEqual(input, false);
+  });
 });

--- a/test/helpers/mock-process.ts
+++ b/test/helpers/mock-process.ts
@@ -8,7 +8,7 @@ import { AbstractPromptOptions } from "../../src/prompts/abstract.js";
 export function mockProcess(inputs: string[] = [], writeCb: (value: string) => void = () => void 0) {
   const stdout = {
     write: (msg: string | Buffer) => {
-      if (msg instanceof Buffer) {
+      if (typeof msg === "object") {
         return;
       }
 
@@ -22,7 +22,7 @@ export function mockProcess(inputs: string[] = [], writeCb: (value: string) => v
     clearLine: () => true
   };
   const stdin = {
-    on: (event, cb) => {
+    on: (_event, cb) => {
       for (const input of inputs) {
         cb(null, input);
       }

--- a/test/multi-select-prompt.test.ts
+++ b/test/multi-select-prompt.test.ts
@@ -919,4 +919,29 @@ describe("MultiselectPrompt", () => {
     ]);
     assert.deepStrictEqual(input, ["foo"]);
   });
+
+  it("should return pre-selected choices when skipping prompt", async() => {
+    const message = "Choose between foo & bar";
+    const options = {
+      choices: ["foo", "bar"],
+      preSelectedChoices: ["bar"],
+      skip: true
+    };
+
+    const input = await multiselect(message, options);
+
+    assert.deepEqual(input, ["bar"]);
+  });
+
+  it("should return '[]' when skipping prompt and no pre-selected choices", async() => {
+    const message = "Choose between foo & bar";
+    const options = {
+      choices: ["foo", "bar"],
+      skip: true
+    };
+
+    const input = await multiselect(message, options);
+
+    assert.deepEqual(input, []);
+  });
 });

--- a/test/question-prompt.test.ts
+++ b/test/question-prompt.test.ts
@@ -160,4 +160,21 @@ describe("QuestionPrompt", () => {
       "✔ What's your name? › CONFIDENTIAL"
     ]);
   });
+
+  it("should return '' when skipping prompt", async() => {
+    const input = await question("What's your name?", {
+      skip: true
+    });
+
+    assert.equal(input, "");
+  });
+
+  it("should return default value when skipping prompt", async() => {
+    const input = await question("What's your name?", {
+      defaultValue: "John Doe",
+      skip: true
+    });
+
+    assert.equal(input, "John Doe");
+  });
 });

--- a/test/select-prompt.test.ts
+++ b/test/select-prompt.test.ts
@@ -705,4 +705,15 @@ describe("SelectPrompt", () => {
     ]);
     assert.equal(input, "foo");
   });
+
+  it("should return first choice when skipping prompt", async() => {
+    const message = "Choose between foo, bar or baz";
+    const options = {
+      choices: ["foo", "bar", "baz"],
+      skip: true
+    };
+    const input = await select(message, options);
+
+    assert.equal(input, "foo");
+  });
 });


### PR DESCRIPTION
Context: I need to implements a `--yes` flag in a CLI (similarly to `npm init --yes`), this option should help 😅 
