### PR TITLE
Expose validation response types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,15 @@
 // Import Internal Dependencies
 import * as prompts from "./src/prompts/index.js";
-import { required, type PromptValidator } from "./src/validators.js";
+import {
+  required,
+  type PromptValidator,
+  type ValidResponseObject,
+  type InvalidResponseObject,
+  type ValidationResponseObject,
+  type ValidationResponse,
+  type InvalidResponse,
+  type ValidResponse
+} from "./src/validators.js";
 import { PromptAgent } from "./src/prompt-agent.js";
 import type { AbstractPromptOptions } from "./src/prompts/abstract.js";
 import type { Choice } from "./src/types.js";
@@ -41,7 +50,13 @@ export type {
   ConfirmOptions,
   Choice,
   MultiselectOptions,
-  SelectOptions
+  SelectOptions,
+  ValidResponseObject,
+  InvalidResponseObject,
+  ValidationResponseObject,
+  ValidationResponse,
+  InvalidResponse,
+  ValidResponse
 };
 
 export {


### PR DESCRIPTION
These types are useful for writing convenience functions and the like. They are already part of the public API indirectly, so the only flexibility lost by exposing them is the ability to rename or condense them.