### PR TITLE
Consistently run eslint on all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepublishOnly": "npm run build",
     "test": "glob -c \"tsx --test\" \"./test/**/*.test.ts\"",
     "coverage": "c8 -r html npm run test",
-    "lint": "eslint src test",
+    "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
I'm not sure why this was changed in #128, but that PR made `npm run eslint` no longer lint the `index.ts` file. This change does not make that script fail on my system.