### PR TITLE
fix(size): Don't build sourcemaps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "./",
-    "types": ["node"]
+    "types": ["node"],
+    "declarationMap": false
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
> Apart of #192 

Pulled out of #195 in case you want to hold off on the breaking change. See https://github.com/TopCli/prompts/pull/195/changes#r3523318203 for more details.

Reduces package size from 201 kB to 110.9 kb, 55% the previous size.

```sh
$ npm run build && npm pack

> @topcli/prompts@3.1.0 build
> tsdown src/index.ts --format cjs,esm --dts --clean

ℹ tsdown v0.22.3 powered by rolldown v1.1.4
ℹ config file: /Users/aklinker1/Development/github.com/others/prompts/package.json
ℹ entry: src/index.ts
ℹ target: node22.0.0
ℹ tsconfig: tsconfig.json
ℹ Build start
ℹ Cleaning 2 files
ℹ [CJS] dist/index.cjs  43.28 kB │ gzip: 8.33 kB
ℹ [CJS] 1 files, total: 43.28 kB
ℹ [CJS] dist/index.d.cts  4.58 kB │ gzip: 1.32 kB
ℹ [CJS] 1 files, total: 4.58 kB
ℹ [ESM] dist/index.mjs    41.10 kB │ gzip: 7.82 kB
ℹ [ESM] dist/index.d.mts   4.66 kB │ gzip: 1.36 kB
ℹ [ESM] 2 files, total: 45.77 kB
✔ Build complete in 516ms
✔ Build complete in 516ms
npm notice
npm notice 📦  @topcli/prompts@3.1.0
npm notice Tarball Contents
npm notice 725B LICENSE
npm notice 14.9kB README.md
npm notice 43.3kB dist/index.cjs
npm notice 4.6kB dist/index.d.cts
npm notice 4.7kB dist/index.d.mts
npm notice 41.1kB dist/index.mjs
npm notice 1.7kB package.json
npm notice Tarball Details
npm notice name: @topcli/prompts
npm notice version: 3.1.0
npm notice filename: topcli-prompts-3.1.0.tgz
npm notice package size: 23.0 kB
npm notice unpacked size: 110.9 kB
npm notice shasum: 04752d4f484ad76f649984e11392995c73b5b285
npm notice integrity: sha512-qgDQI8rlCGzXX[...]M9SDkXDw5DMng==
npm notice total files: 7
npm notice
topcli-prompts-3.1.0.tgz
```